### PR TITLE
fix: Remove duplicate useAuth import in SellerManagementPage.tsx

### DIFF
--- a/src/pages/SellerManagementPage.tsx
+++ b/src/pages/SellerManagementPage.tsx
@@ -38,7 +38,6 @@ import {
   AlertDialogTrigger, 
 } from "@/components/ui/alert-dialog";
 import { useNavigate } from 'react-router-dom'; 
-import { useAuth } from '@/contexts/AuthContext'; // Ensure useAuth is imported
 
 const SellerManagementPage = () => {
   const navigate = useNavigate(); 


### PR DESCRIPTION
This resolves a syntax error that prevented the page from loading.