### PR TITLE
fix: Add uuid package and types to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",
@@ -79,6 +80,7 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "@types/uuid": "^9.0.8"
   }
 }


### PR DESCRIPTION
Adds `uuid` to dependencies and `@types/uuid` to devDependencies in package.json. This is required for `supabaseStorage.ts` to resolve import errors and allow unique filename generation for photo uploads.