### PR TITLE
fix: Resolve ReferenceError in GoalProgress.tsx

### DIFF
--- a/src/components/dashboard/GoalProgress.tsx
+++ b/src/components/dashboard/GoalProgress.tsx
@@ -1,5 +1,5 @@
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
-import { Target, Info } from "lucide-react"; // Removed ShieldCheck, Star
+import { Target, Info, ShieldCheck, Star } from "lucide-react";
 import type { SellerProfile } from "@/lib/supabaseQueries"; // Updated type to SellerProfile
 
 interface GoalProgressProps {


### PR DESCRIPTION
Re-adds ShieldCheck and Star to lucide-react imports to prevent ReferenceError that was causing a blank page. These icons are used as visual placeholders alongside N/A data.