### PR TITLE
fix: Add ON DELETE CASCADE to sales_records & improve photo error han…

### DIFF
--- a/src/pages/SellerManagementPage.tsx
+++ b/src/pages/SellerManagementPage.tsx
@@ -114,8 +114,20 @@ const SellerManagementPage = () => {
             }
             newPhotoUrl = uploadResult.publicUrl; // Use the publicUrl string
             toast.success("Foto enviada com sucesso!");
-          } else {
-            toast.error(`Falha ao enviar a nova foto: ${uploadResult.error?.message || 'Erro desconhecido no upload.'} O perfil será atualizado sem alterar a foto.`);
+          } else { // Photo upload to storage FAILED
+            let photoErrorMessage = "Erro desconhecido no upload.";
+            if (uploadResult.error) {
+              if (typeof uploadResult.error.message === 'string' && uploadResult.error.message.length > 0) {
+                photoErrorMessage = uploadResult.error.message;
+              } else if (typeof (uploadResult.error as any).error === 'string' && (uploadResult.error as any).error.length > 0) { // Check for Supabase specific error.error
+                photoErrorMessage = (uploadResult.error as any).error;
+              } else if (typeof uploadResult.error === 'string' && uploadResult.error.length > 0) {
+                photoErrorMessage = uploadResult.error;
+              }
+              // Log the full error object from uploadSellerPhoto for detailed inspection
+              console.error("[handleDialogSubmit - Edit Seller] Full photo upload error object:", JSON.stringify(uploadResult.error, null, 2));
+            }
+            toast.error(`Falha ao enviar a nova foto: ${photoErrorMessage}. O perfil será atualizado sem alterar a foto.`);
             // newPhotoUrl remains editingSeller.photo_url (or its initial value)
           }
         }
@@ -169,9 +181,20 @@ const SellerManagementPage = () => {
             } else {
               toast.success("Vendedor e foto adicionados com sucesso!");
             }
-          } else {
-            // uploadResult.error contains the error from uploadSellerPhoto
-            toast.warning(`Vendedor adicionado, mas falha ao enviar foto: ${uploadResult.error?.message || 'Erro desconhecido no upload.'}`);
+          } else { // Photo upload to storage FAILED
+            let photoErrorMessage = "Erro desconhecido no upload.";
+            if (uploadResult.error) {
+              if (typeof uploadResult.error.message === 'string' && uploadResult.error.message.length > 0) {
+                photoErrorMessage = uploadResult.error.message;
+              } else if (typeof (uploadResult.error as any).error === 'string' && (uploadResult.error as any).error.length > 0) { // Check for Supabase specific error.error
+                photoErrorMessage = (uploadResult.error as any).error;
+              } else if (typeof uploadResult.error === 'string' && uploadResult.error.length > 0) {
+                photoErrorMessage = uploadResult.error;
+              }
+              // Log the full error object from uploadSellerPhoto for detailed inspection
+              console.error("[handleDialogSubmit - Add Seller] Full photo upload error object:", JSON.stringify(uploadResult.error, null, 2));
+            }
+            toast.warning(`Vendedor adicionado, mas falha ao enviar foto: ${photoErrorMessage}`);
           }
           queryClient.invalidateQueries({ queryKey: ['allSellerProfiles'] });
           setIsAddEditDialogOpen(false);

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -44,7 +44,7 @@ ALTER TABLE public.kpis ENABLE ROW LEVEL SECURITY;
 -- Table for individual sales transaction records
 CREATE TABLE public.sales_records (
     id UUID PRIMARY KEY DEFAULT extensions.uuid_generate_v4(),
-    salesperson_id UUID NOT NULL REFERENCES public.salespeople(id),
+    salesperson_id UUID NOT NULL REFERENCES public.salespeople(id) ON DELETE CASCADE,
     amount NUMERIC NOT NULL,
     sale_date DATE NOT NULL,
     is_new_customer BOOLEAN DEFAULT false,


### PR DESCRIPTION
…dling

- Modifies supabase_schema.sql: sales_records.salesperson_id FK now has ON DELETE CASCADE.
- SellerManagementPage.tsx: Enhances handleDialogSubmit to provide more specific toasts for photo upload failures and logs the full error object from uploadSellerPhoto for better diagnostics.