### PR TITLE
refactor: Simplify file path for seller photo uploads in supabaseStor…

### DIFF
--- a/src/lib/supabaseStorage.ts
+++ b/src/lib/supabaseStorage.ts
@@ -19,7 +19,7 @@ export const uploadSellerPhoto = async (
 
   const fileExtension = file.name.split('.').pop();
   const fileName = `${uuidv4()}.${fileExtension}`;
-  const filePath = `public/${sellerId}/${fileName}`; // Store in a 'public' folder within bucket for easier public access setup
+  const filePath = `${sellerId}/${fileName}`; // Store in a 'public' folder within bucket for easier public access setup
 
   const { error: uploadError } = await supabase.storage
     .from(SELLER_AVATARS_BUCKET)


### PR DESCRIPTION
…age.ts

Removes the 'public/' prefix from the filePath construction in `uploadSellerPhoto`. The path is now `${sellerId}/${fileName}`. This is part of an effort to diagnose upload issues and will be paired with advice for a simplified storage RLS policy for testing.