### PR TITLE
Fix: Resolve ReferenceError in SalespersonRanking

### DIFF
--- a/src/components/dashboard/SalespersonRanking.tsx
+++ b/src/components/dashboard/SalespersonRanking.tsx
@@ -118,7 +118,7 @@ export const SalespersonRanking = ({ salespeople }: SalespersonRankingProps) => 
       </CardHeader>
       <CardContent className="p-4">
         <div className="space-y-3">
-          {sortedSalespeople.map((person, index) => (
+          {rankedSalespeople.map((person, index) => (
               <div
                 key={person.id} // Use id as key
                 onClick={() => handlePersonClick(person)}


### PR DESCRIPTION
Corrects a ReferenceError in SalespersonRanking.tsx by ensuring it uses the defined 'rankedSalespeople' variable instead of the undefined 'sortedSalespeople' for rendering the list. This allows the component to render with the performance data.

Includes previous diagnostic logging and refactoring.